### PR TITLE
Updating immutant to 2.1.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.immutant/immutant "2.x.incremental.706"]
+                 [org.immutant/immutant "2.1.2"]
                  [compojure "1.4.0"]
                  [ring/ring-devel "1.3.1"]
                  [org.clojure/core.memoize "0.5.6"]


### PR DESCRIPTION
- Throws ClassCastException, oddly

```
Caused by: java.lang.ClassCastException: java.net.URL cannot be cast to java.security.KeyStore
	at immutant.web.ssl$keystore__GT_key_managers.invoke(ssl.clj:33)
	at immutant.web.ssl$keystore__GT_ssl_context.invoke(ssl.clj:55)
	at immutant.web.undertow$ssl_context.invoke(undertow.clj:93)
	at clojure.core$comp$fn__4495.invoke(core.clj:2438)
	at clojure.core$comp$fn__4495.invoke(core.clj:2438)
	at clojure.core$comp$fn__4495.invoke(core.clj:2438)
	at clojure.core$comp$fn__4495.invoke(core.clj:2438)
	at clojure.core$comp$fn__4495.invoke(core.clj:2438)
	at clojure.core$comp$fn__4495.invoke(core.clj:2438)
	at clojure.core$comp$fn__4495.invoke(core.clj:2438)
	at clojure.core$comp$fn__4495.invoke(core.clj:2438)
	at immutant.web.undertow$options_maybe.invoke(undertow.clj:165)
	at clojure.lang.Var.invoke(Var.java:379)
	at immutant.web$run.doInvoke(web.clj:94)
	at clojure.lang.RestFn.invoke(RestFn.java:423)
	at demo.web$_main.doInvoke(web.clj:52)
	at clojure.lang.RestFn.invoke(RestFn.java:397)
	at clojure.lang.AFn.applyToHelper(AFn.java:152)
	at clojure.lang.RestFn.applyTo(RestFn.java:132)
	at clojure.core$apply.invoke(core.clj:630)
	at demo.core$_main.doInvoke(core.clj:10)
	at clojure.lang.RestFn.invoke(RestFn.java:397)
	at clojure.lang.Var.invoke(Var.java:375)
	at user$eval5.invoke(form-init8247050323861244764.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:6782)
	at clojure.lang.Compiler.eval(Compiler.java:6772)
	at clojure.lang.Compiler.load(Compiler.java:7227)
```